### PR TITLE
Fix example

### DIFF
--- a/R/az_group.R
+++ b/R/az_group.R
@@ -35,7 +35,7 @@
 #' usr <- gr$get_user("myname@aadtenant.com")
 #'
 #' grps <- usr$list_direct_memberships()
-#' grp <- grp[[1]]
+#' grp <- gr$get_group(grps[1])
 #'
 #' grp$list_members()
 #' grp$list_owners()

--- a/man/az_group.Rd
+++ b/man/az_group.Rd
@@ -47,7 +47,7 @@ gr <- get_graph_login()
 usr <- gr$get_user("myname@aadtenant.com")
 
 grps <- usr$list_direct_memberships()
-grp <- grp[[1]]
+grp <- gr$get_group(grps[1])
 
 grp$list_members()
 grp$list_owners()


### PR DESCRIPTION
When I was running as in the example, I noticed that `grp` is a charactor and I can't run `grp$list_members()` or `grp$list_owners()`.