### PR TITLE
shrinking the memory profile of an R6 object down

### DIFF
--- a/AzureGraph.Rproj
+++ b/AzureGraph.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
A proposal:

consider shrinking the memory profile of an R6 object down by applying portable=F and cloneable=F to `ms_object`