### PR TITLE
Encode hash (#) in URL path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AzureGraph
 Title: Simple Interface to 'Microsoft Graph'
-Version: 1.3.2
+Version: 1.3.3
 Authors@R: c(
     person("Hong", "Ooi", , "hongooi73@gmail.com", role = c("aut", "cre")),
     person("Microsoft", role="cph")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# AzureGraph 1.3.3
+
+- Paths containing a hash (#) are encoded in `call_graph_endpoint()` and no longer fail with 404
+
 # AzureGraph 1.3.2
 
 - Minor backend fixes.

--- a/R/call_graph.R
+++ b/R/call_graph.R
@@ -32,6 +32,7 @@ call_graph_endpoint <- function(token, operation, ..., options=list(),
 {
     url <- find_resource_host(token)
     url$path <- construct_path(api_version, operation)
+    url$path <- encode_hash(url$path)
     url$query <- options
 
     call_graph_url(token, url, ...)
@@ -138,6 +139,11 @@ construct_path <- function(...)
     sub("/$", "", file.path(..., fsep="/"))
 }
 
+# paths containing hash need to be encoded
+encode_hash <- function(x)
+{
+    gsub("#", "%23", x, fixed = TRUE)
+}
 
 # display confirmation prompt, return TRUE/FALSE (no NA)
 get_confirmation <- function(msg, default=TRUE)


### PR DESCRIPTION
I'm using this package via [{Microsoft365R}](https://github.com/Azure/Microsoft365R) accessing a sharepoint drive containing some 'directories' which have a hash in their path, e.g.

```
/root path/dir1/dir2/dir3/dir#4_some suffix
```

The current (v1.3.2) implementation of `call_graph_endpoint()` performs some path cleanup via `construct_path()` 

https://github.com/Azure/AzureGraph/blob/5176cccc88cc895340fd811797f40e62e83c0a67/R/call_graph.R#L34

but this does not affect the hashes. The API seems incompatible with this, and an error results

```
Error in process_response(res, match.arg(http_status_handler), simplify) : 
  Not Found (HTTP 404). Failed to complete operation. Message:
The resource could not be found.
```

This PR adds an additional substitution of `"#"` to the URLencoded `"%23"`. This _could_ also be achieved with `URLencode("#", reserved = TRUE)` which returns the same but I wanted to avoid accidentally encoding the already converted values.

I have successfully tested this with a private sharepoint I have access to but I am not sufficiently experienced with sharepoint or other use-cases of this package to know if this causes any other issues.